### PR TITLE
Video loop feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ A JSON example of the stories object:
     {
       id: "",       // item id
       type: "",     // photo or video
-      length: 3,    // photo timeout or video length in seconds - uses 3 seconds timeout for images if not set
+      length: 3,    // photo timeout or video length in seconds - uses 3 seconds as default
+      loop: false,  // loop video if needed. Makes no sense if video real duration is greater than length. Use case: mp4 gifs
       src: "",      // photo or video src
       preview: "",  // optional - item thumbnail to show in the story carousel instead of the story defined image
       link: "",     // a link to click on story

--- a/src/zuck.js
+++ b/src/zuck.js
@@ -314,6 +314,7 @@ module.exports = (window => {
             data-linkText="${get(itemData, 'linkText')}"
             data-time="${get(itemData, 'time')}"
             data-type="${get(itemData, 'type')}"
+            data-loop="${get(itemData, 'loop')}"
             data-length="${get(itemData, 'length')}"
           `;
 
@@ -380,7 +381,7 @@ module.exports = (window => {
                     data-time="${get(item, 'time')}" data-type="${get(item, 'type')}" data-index="${index}" data-item-id="${get(item, 'id')}">
                     ${
                       get(item, 'type') === 'video'
-                      ? `<video class="media" muted webkit-playsinline playsinline preload="auto" src="${get(item, 'src')}" ${get(item, 'type')}></video>
+                      ? `<video class="media" data-length="${item.length}" ${!!item.loop ? 'loop' : ''} muted webkit-playsinline playsinline preload="auto" src="${get(item, 'src')}" ${get(item, 'type')}></video>
                         <b class="tip muted">${option('language', 'unmute')}</b>`
                       : `<img loading="auto" class="media" src="${get(item, 'src')}" ${get(item, 'type')} />
                     `}
@@ -1161,11 +1162,15 @@ module.exports = (window => {
         }
 
         const setDuration = function () {
-          if (video.duration) {
+          let duration = video.duration;
+          if (+video.dataset.length) {
+            duration = +video.dataset.length;
+          }
+          if (duration) {
             setVendorVariable(
               itemPointer.getElementsByTagName('b')[0].style,
               'AnimationDuration',
-              `${video.duration}s`
+              `${duration}s`
             );
           }
         };
@@ -1461,11 +1466,12 @@ module.exports = (window => {
     return timelineItem;
   };
 
-  ZuckJS.buildStoryItem = (id, type, length, src, preview, link, linkText, seen, time) => {
+  ZuckJS.buildStoryItem = (id, type, length, src, loop, preview, link, linkText, seen, time) => {
     return {
       id,
       type,
       length,
+      loop,
       src,
       preview,
       link,


### PR DESCRIPTION
Hi!

We are using zuck.js in our project. Thanks for great script

Recently we noticed that our feature with gifs in stories is creating very short story. So we decided to loop video (gifs are mp4 actually).
Unfortunately length was not working for videos. And also there was no ability to start looping the video. 

So this PR contains 2 features:
1. Fixed length option for videos. Video will not play till end or will be stopped untill story ends
2. Looping for videos. Very useful for short mp4 that was created as gif