### PR TITLE
Show story time using VemDeZAP and Snapssenger

### DIFF
--- a/src/zuck.js
+++ b/src/zuck.js
@@ -298,7 +298,7 @@ module.exports = (window => {
                 </span>
                 <span class="info" itemProp="author" itemScope itemType="http://schema.org/Person">
                   <strong class="name" itemProp="name">${get(itemData, 'name')}</strong>
-                  <span class="time">${get(itemData, 'lastUpdatedAgo')}</span>
+                  <span class="time">${timeAgo(get(itemData, 'lastUpdated'))}</span>
                 </span>
               </a>
               


### PR DESCRIPTION
Fixes #89 update zuck.js item template so it shows the story time using both VemDeZAP and Snapssenger themes and adds the `timeAgo` formatting to the story timestamp