### PR TITLE
Fix video start point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -441,6 +441,10 @@ export const Zuck: ZuckFunction = function (timeline, options) {
         data[currentStoryIndex].currentItem =
           data[currentStoryIndex].currentItem + directionNumber;
 
+        const nextVideo = nextItem.querySelector('video');
+        if (nextVideo) {
+          nextVideo.currentTime = 0;
+        }
         playVideoItem(storyViewer, nextItems, event);
       };
 


### PR DESCRIPTION
Hey there! Using the package I noticed that when navigating back and forth between videos, it always restarted from the paused point.
Since the library seems to reproduce Instagram/WhatsApp stories and so on, it looks like something to be fixed, like reported on that issue https://github.com/ramonszo/zuck.js/issues/126

Anyway, I tried some stuff and that seems to be a good solution, what do you think?

---
Valeu Ramon! 🤟🏻