### PR TITLE
fix: a11y tags

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -57,15 +57,20 @@ export const optionsDefault = (option?: ZuckObject['option']): Options => ({
     timelineItem(itemData: TimelineItem) {
       return `
         <div class="story ${itemData['seen'] === true ? 'seen' : ''}">
-          <a class="item-link" ${
-            itemData['link'] ? `href="${itemData['link'] || ''}"` : ''
-          }>
+          <a
+            aria-label="View ${itemData['name']} Story"
+            class="item-link" 
+            ${itemData['link'] ? `href="${itemData['link'] || ''}"` : ''}
+          >
             <span class="item-preview">
-              <img lazy="eager" src="${
-                option('avatars') || !itemData['currentPreview']
+              <img 
+                lazy="eager" 
+                alt="${itemData['name']}"
+                src="${option('avatars') || !itemData['currentPreview']
                   ? itemData['photo']
                   : itemData['currentPreview']
-              }" />
+                }" 
+              />
             </span>
             <span class="info" itemProp="author" itemScope itemType="http://schema.org/Person">
               <strong class="name" itemProp="name">${itemData['name']}</strong>


### PR DESCRIPTION
This pull request includes a change to improve the accessibility and user experience of the `timelineItem` function in the `src/options.ts` file. The key updates involve adding ARIA labels and alt attributes for better accessibility.

Accessibility improvements:

* Added `aria-label` to the anchor tag to provide a descriptive label for screen readers.
* Included `alt` attribute in the image tag to describe the image content for screen readers.